### PR TITLE
Fix false if elem gets hidden with style applied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.DS_Store
 **/settings.json
+**/*.code-workspace

--- a/src/reken.js
+++ b/src/reken.js
@@ -62,7 +62,7 @@ function buildClasses(componentRoot, elem, elemString, compString, topForString,
     } 
 
     let orderedKeys = []
-    let firsts = ['component', 'if', 'for', 'attr-value']; // Need to be first in that order.
+    let firsts = ['component', 'style', 'if', 'for', 'attr-value']; // Need to be first in that order.
     for (let first of firsts) {
         let indexInKeys = keys.indexOf(first);
         if (indexInKeys >= 0) {

--- a/test/test-reken.html
+++ b/test/test-reken.html
@@ -240,6 +240,7 @@
     let if1 = true;
     let if2 = true;
     let if3 = false;
+    let if4 = true;
   </script>
   <section>
     <h3>data-if tests</h3>
@@ -262,6 +263,10 @@
       <span data-text="${if3_1.index}"></span>
     </div>
     <label>if3:<input id="i3_1" type="checkbox" data-value="if3"></label>
+
+    <div id="i4" data-if="if4" data-style="background:rgb(255, 0, 0)">if/style test
+    </div>
+    <label>if4:<input id="i4_1" type="checkbox" data-value="if4"></label>
   </section>
   <hr>
 
@@ -884,7 +889,21 @@
 
         done();
       })
+      it('Make sure that if element works with data-style attribute', (done) => {
+        expect($('i4')).to.be.displayed;
+        expect($('i4_1').checked).to.be.true;
+        expect($('i4')).to.have.style('background-color', 'rgb(255, 0, 0)');
+
+        //Make true; Ie show and execute element
+        $('i4_1').checked = false;
+        $('i4_1').dispatchEvent(new Event('change'));
+        expect($('i4')).not.to.be.displayed;
+        expect($('i4_1').checked).to.be.false;
+        expect($('i4')).to.have.style('background-color', 'rgb(255, 0, 0)');
+        done();
+      })      
     })
+    
     describe('data-action tests', () => {
       it('Press button to increment js number a0', (done) => {
         expect(a0).to.equal(0);


### PR DESCRIPTION
Issue: data-style settings were overwriting the display:none style setting when a data-if evaluated negative on the same element. Resulting on elements not being hidden.
Resolution: Change the order of execution. data-style now gets processed before data-if.